### PR TITLE
Replace endpoint name from `regist` to `register`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Slack App経由でRedisに情報を登録して、ボットがそれらの情報
 ### アプリの作成
 1. [Slack API](https://api.slack.com/apps) の画面でCreate Appを押下してください。
 2. アプリを作成したら、 `Slack Commands` に下記のように登録します。
-  1. `/afk` リクエストエンドポイント `https://<your domain>/regist`
-  2. `/lunch` リクエストエンドポイント `https://<your domain>/regist`
+  1. `/afk` リクエストエンドポイント `https://<your domain>/register`
+  2. `/lunch` リクエストエンドポイント `https://<your domain>/register`
   3. `/comeback` リクエストエンドポイント `https://<your domain>/delete`
 
 ### ボットユーザーの作成

--- a/app/api.rb
+++ b/app/api.rb
@@ -27,11 +27,11 @@ module App
       payload["challenge"]
     end
 
-    post '/regist' do
+    post '/register' do
       content_type 'text/plain; charset=utf8'
       uid = params["user_id"]
       reset(uid)
-      Redis.current.lpush("registed", uid)
+      Redis.current.lpush("registered", uid)
       case params["command"]
       when "/afk"
         unless params["text"].empty?
@@ -57,7 +57,7 @@ module App
     end
 
     def reset(id)
-      Redis.current.lrem("registed", 0, id)
+      Redis.current.lrem("registered", 0, id)
       Redis.current.del(id)
     end
   end

--- a/bot.rb
+++ b/bot.rb
@@ -8,7 +8,7 @@ server = SlackRubyBot::Server.new(
   token: ENV['SLACK_API_TOKEN'],
   hook_handlers: {
     message: [->(client, data) {
-      entries = Redis.current.lrange("registed", 0, -1)
+      entries = Redis.current.lrange("registered", 0, -1)
       mention = entries.find do |entry|
         data.text =~ /<@#{entry}>/
       end


### PR DESCRIPTION
I am really appreciated for the endeavor that aims to improve the productivity of world-wide Slack users.

The reason why I am now to make a proposal is that I would like to suggest an alternative about the name of an endpoint. With all due respect, I dare say that you might want to have named `register` for the endpoint instead of `regist.` I would be happy if you would consider this issue.